### PR TITLE
Fixed issue where github releases were improperly tagged

### DIFF
--- a/docker/base/pipeline.yml
+++ b/docker/base/pipeline.yml
@@ -127,19 +127,18 @@ jobs:
           load_repository: (( grab meta.dockerhub.repository ))
           load_tag:        edge
 
-      - aggregate:
-        - put: version
-          params:
-            bump: patch
-        - put: git
-          params:
-            rebase: true
-            repository: pushme/git
-        - put: github
-          params:
-            name: gh/name
-            tag:  gh/tag
-            body: gh/notes.md
+      - put: version
+        params:
+          bump: patch
+      - put: git
+        params:
+          rebase: true
+          repository: pushme/git
+      - put: github
+        params:
+          name: gh/name
+          tag:  gh/tag
+          body: gh/notes.md
 
 resource_types:
   - name: slack-notification

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -170,19 +170,18 @@ jobs:
           load_repository: (( grab meta.dockerhub.repository ))
           load_tag:        edge
 
-      - aggregate:
-        - put: version
-          params:
-            bump: patch
-        - put: source
-          params:
-            rebase: true
-            repository: pushme/source
-        - put: github
-          params:
-            name: gh/name
-            tag:  gh/tag
-            body: gh/notes.md
+      - put: version
+        params:
+          bump: patch
+      - put: source
+        params:
+          rebase: true
+          repository: pushme/source
+      - put: github
+        params:
+          name: gh/name
+          tag:  gh/tag
+          body: gh/notes.md
 
 resource_types:
   - name: slack-notification

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -132,19 +132,18 @@ jobs:
             BRANCH:       (( grab meta.github.branch ))
             CMD_PKG:      (( grab meta.go.cmd_module ))
 
-      - aggregate:
-        - put: version
-          params: { bump: final }
-        - put: git
-          params:
-            rebase: true
-            repository: pushme/git
-        - put: github
-          params:
-            name:   gh/name
-            tag:    gh/tag
-            body:   gh/notes.md
-            globs: [gh/artifacts/*]
+      - put: version
+        params: { bump: final }
+      - put: git
+        params:
+          rebase: true
+          repository: pushme/git
+      - put: github
+        params:
+          name:   gh/name
+          tag:    gh/tag
+          body:   gh/notes.md
+          globs: [gh/artifacts/*]
 
 resource_types:
   - name: slack-notification


### PR DESCRIPTION
Occasionally, the pipelines for go/docker were tagging releases
on the commit immediately prior to the commit for generating the release.
We now push up the refs for the release prior to creating the release,
so that GitHub will use the correct ref to perform the release.

Fixes #9
