### PR TITLE
fast 'repipe url' command to construct concourse dashboard url

### DIFF
--- a/repipe
+++ b/repipe
@@ -44,6 +44,22 @@ usage() {
     echo "url               Pipeline dashboard URL. Usage: ci/repipe url | xargs -L1 open"
 }
 
+open_pipeline() {
+	url=$(show_pipeline_url)
+	if [[ -x /usr/bin/open ]]; then
+		exec /usr/bin/open "$url"
+	else
+		echo "Sorry, but I was not able to automagically open"
+		echo "your Concourse Pipeline in the browser."
+		echo
+		echo "Here's a link you can click on, though:"
+		echo
+		echo "  $url"
+		echo
+		exit 0;
+	fi
+}
+
 show_pipeline_url() {
 	spruce merge --skip-eval pipeline.yml ${settings_file} > .deploy.yml
 	concourse_url=$(spruce json .deploy.yml | jq -r ".meta.url")
@@ -65,6 +81,7 @@ for arg do
         validate-strict|validate_strict) VALIDATE_PIPELINE="strict" ;;
         non-interactive|non_interactive) NON_INTERACTIVE="--non-interactive" ;;
         url) SHOW_PIPELINE_URL="yes" ;;
+        open) OPEN_PIPELINE="yes" ;;
         help|-h|--help) usage; exit 0 ;;
         *) echo Invalid argument
             usage
@@ -90,6 +107,7 @@ set -e
 trap "cleanup" QUIT TERM EXIT INT
 
 [[ -n ${SHOW_PIPELINE_URL} ]] && { show_pipeline_url; exit 0; }
+[[ -n ${OPEN_PIPELINE} ]]     && { open_pipeline;     exit 0; }
 
 spruce merge pipeline.yml ${settings_file} > .deploy.yml
 PIPELINE=$(spruce json .deploy.yml | jq -r '.meta.pipeline // ""')

--- a/repipe
+++ b/repipe
@@ -41,7 +41,7 @@ usage() {
     echo "validate          Validate pipeline instead of set pipeline"
     echo "validate-strict   Validate pipeline with strict mode"
     echo "non-interactive   Run set-pipeline in non-interactive mode"
-    echo "url               Pipeline dashboard URL. Usage: ci/repipe url | xargs -L1 open"
+    echo "open              Open pipeline dashboard to browser (if possible)"
 }
 
 open_pipeline() {

--- a/repipe
+++ b/repipe
@@ -41,6 +41,20 @@ usage() {
     echo "validate          Validate pipeline instead of set pipeline"
     echo "validate-strict   Validate pipeline with strict mode"
     echo "non-interactive   Run set-pipeline in non-interactive mode"
+    echo "url               Pipeline dashboard URL. Usage: ci/repipe url | xargs -L1 open"
+}
+
+show_pipeline_url() {
+	spruce merge --skip-eval pipeline.yml ${settings_file} > .deploy.yml
+	concourse_url=$(spruce json .deploy.yml | jq -r ".meta.url")
+	team=$(spruce json .deploy.yml | jq -r ".meta.team // \"main\"")
+	pipeline=$(spruce merge --skip-eval \
+		--cherry-pick meta.pipeline \
+		--cherry-pick meta.name \
+		.deploy.yml | spruce merge - | spruce json | jq -r ".meta.pipeline")
+
+	echo "$concourse_url/teams/$team/pipelines/$pipeline"
+	exit 0
 }
 
 for arg do
@@ -50,6 +64,7 @@ for arg do
         validate) VALIDATE_PIPELINE="normal" ;;
         validate-strict|validate_strict) VALIDATE_PIPELINE="strict" ;;
         non-interactive|non_interactive) NON_INTERACTIVE="--non-interactive" ;;
+        url) SHOW_PIPELINE_URL="yes" ;;
         help|-h|--help) usage; exit 0 ;;
         *) echo Invalid argument
             usage
@@ -58,7 +73,7 @@ for arg do
 done
 
 cd $(dirname $BASH_SOURCE[0])
-echo "Working in $(pwd)"
+echo >&2 "Working in $(pwd)"
 need_command spruce
 
 # Allow for target-specific settings
@@ -73,6 +88,9 @@ echo >&2 "Using settings found in ${settings_file}"
 
 set -e
 trap "cleanup" QUIT TERM EXIT INT
+
+[[ -n ${SHOW_PIPELINE_URL} ]] && { show_pipeline_url; exit 0; }
+
 spruce merge pipeline.yml ${settings_file} > .deploy.yml
 PIPELINE=$(spruce json .deploy.yml | jq -r '.meta.pipeline // ""')
 if [[ -z ${PIPELINE} ]]; then


### PR DESCRIPTION
Script is in https://github.com/cloudfoundry-community/mattermost-boshrelease already for a demo.

On OSX:

```
git clone https://github.com/cloudfoundry-community/mattermost-boshrelease
cd mattermost-boshrelease
ci/repipe url | xargs -L1 open
```

I'd really like `ci/repipe open` but couldn't get that working. Ideas?