### PR TITLE
boshrelease backport improvements from live pipelines

### DIFF
--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -70,8 +70,11 @@ groups:
       - testflight-pr
       - rc
       - shipit
+  - name: versioning
+    jobs:
       - major
       - minor
+      - patch
 
 jobs:
   - name: testflight
@@ -263,6 +266,20 @@ jobs:
           username: (( grab meta.slack.username ))
           icon_url: (( grab meta.slack.icon ))
           text:    '(( concat meta.slack.fail_url " " meta.pipeline ": minor job failed" ))'
+
+  - name: patch
+    public: true
+    plan:
+    - do:
+      - { get: version, trigger: false, params: {bump: patch} }
+      - { put: version,                 params: {file: version/number} }
+      on_failure:
+        put: notify
+        params:
+          channel:  (( grab meta.slack.channel ))
+          username: (( grab meta.slack.username ))
+          icon_url: (( grab meta.slack.icon ))
+          text:    '(( concat meta.slack.fail_url " " meta.pipeline ": patch job failed" ))'
 
   - name: major
     public: true

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -205,11 +205,41 @@ jobs:
 
   - name: rc
     public: true
+    serial: true
     plan:
     - do:
       - aggregate:
           - { get: git,     trigger: true,  passed: [testflight] }
           - { get: version, trigger: true, params: {pre: rc} }
+      - task: release-notes
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: (( grab meta.image.name ))
+              tag:        (( grab meta.image.tag ))
+          inputs:
+              - { name: git }
+          run:
+            path: sh
+            args:
+            - -ce
+            - |
+              cd git
+              if [ -f ci/release_notes.md ]; then
+                echo "######   RELEASE NOTES   ###############"
+                echo
+                cat ci/release_notes.md
+                echo
+                echo "########################################"
+                echo
+              else
+                echo "NO RELEASE NOTES HAVE BEEN WRITTEN"
+                echo "You *might* want to do that before"
+                echo "hitting (+) on that shipit job..."
+                echo
+              fi
       - put: version
         params: {file: version/number}
       on_failure:

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -376,6 +376,7 @@ resources:
 
   - name: git-pull-requests
     type: pull-request
+    check_every: 15m # Required due to API throttling.
     source:
       access_token: (( grab meta.github.access_token ))
       private_key:  (( grab meta.github.private_key ))

--- a/boshrelease/scripts/shipit
+++ b/boshrelease/scripts/shipit
@@ -75,7 +75,7 @@ echo "SHA1=$SHA1"
 
 mkdir -p ${RELEASE_ROOT}/artifacts
 echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag
-echo "v${VERSION}"                         > ${RELEASE_ROOT}/name
+echo "${RELEASE_NAME} v${VERSION}"         > ${RELEASE_ROOT}/name
 mv ${REPO_ROOT}/releases/*/*-${VERSION}.tgz  ${RELEASE_ROOT}/artifacts
 mv ${REPO_ROOT}/ci/release_notes.md          ${RELEASE_ROOT}/notes.md
 cat >> ${RELEASE_ROOT}/notes.md <<EOF
@@ -83,10 +83,10 @@ cat >> ${RELEASE_ROOT}/notes.md <<EOF
 ### Deployment
 \`\`\`yaml
 releases:
-- name: $RELEASE_NAME
+- name:    $RELEASE_NAME
   version: $VERSION
-  url: https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz
-  sha1: $SHA1
+  url:     https://github.com/${GITHUB_OWNER}/${RELEASE_NAME}-boshrelease/releases/download/v${VERSION}/${RELEASE_NAME}-${VERSION}.tgz
+  sha1:    $SHA1
 \`\`\`
 EOF
 cat > ${RELEASE_ROOT}/notification <<EOF


### PR DESCRIPTION
Some minor fixes backported into the templates found when upgrading the existing boshrelease pipelines to use bosh2 instead of bosh1:

- only check the PRs every 15 minutes because otherwise GitHub API throttling occurs.
- Display the release notes as part of the rc task
- Move versioning to its own group, and add patch bump 
  - sometimes patch gets used but not bumped due to github failure, so required manual edit of s3 bucket.  This makes it possible to resolve directly in pipeline.
- Put the name back in the release name file.
