### PR TITLE
Bugfix: add missing stemcell CPI & OS properties

### DIFF
--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -449,6 +449,8 @@ jobs:
             BOSH_CA_CERT:         (( grab meta.bosh.cacert ))
             BOSH_CLIENT:          (( grab meta.bosh.username ))
             BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
+            STEMCELL_CPI:         (( grab meta.bosh.stemcell.cpi ))
+            STEMCELL_OS:          (( grab meta.bosh.stemcell.os ))
       - put: compiled-release
         params:
           file: (( concat "compiled-release/compiled-releases/" meta.name "/*.tgz" ))
@@ -487,11 +489,12 @@ jobs:
           run:
             path: git/ci/scripts/use-compiled-releases
           params:
-            REPO_ROOT: git
-            REPO_OUT:  pushme
-            GIT_EMAIL: (( grab meta.git.email ))
-            GIT_NAME:  (( grab meta.git.name ))
-            BRANCH:    (( grab meta.github.branch ))
+            REPO_ROOT:     git
+            REPO_OUT:      pushme
+            GIT_EMAIL:     (( grab meta.git.email ))
+            GIT_NAME:      (( grab meta.git.name ))
+            BRANCH:        (( grab meta.github.branch ))
+            STEMCELL_OS:   (( grab meta.bosh.stemcell.os ))
       - name: upload-git
         put: git
         params:


### PR DESCRIPTION
Hi,

After updating my pipelines to the latest master version, I noticed those missing properties that make them break when not using the AWS CPI.

Sorry if this bugfix makes my currently-open PR conflict. I wanted to separate this one because it's not about improvements, it's about bugfixing an issue. Don't hesitate to ask me to rebase.

Best