### PR TITLE
Factor CI image configs into single resource (on top of #40)

### DIFF
--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -20,6 +20,9 @@ meta:
   image:
     name: starkandwayne/concourse
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   binaries: '*'
   bin_dir: bin
@@ -211,6 +214,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -225,7 +225,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))

--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -63,11 +63,9 @@ jobs:
     public: true
     serial: true
     plan:
-      - name: testing
-        do:
-        - { name: inputs, get: git, trigger: true }
-        - name: run_tests
-          task: test
+      - do:
+        - { get: git, trigger: true }
+        - task: test
           config:
             platform: linux
             image_resource:
@@ -155,12 +153,10 @@ jobs:
     serial: true
     plan:
       - do:
-        - name: inputs
-          in_parallel:
+        - in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
-        - name: release
-          task: release
+        - task: release
           config:
             image_resource:
               type: docker-image
@@ -185,16 +181,13 @@ jobs:
               RELEASE_ROOT: gh
               REPO_OUT:     pushme
               BRANCH:       (( grab meta.github.branch ))
-        - name: version
-          put: version
+        - put: version
           params: { bump: final }
-        - name: git
-          put: git
+        - put: git
           params:
             rebase: true
             repository: pushme/git
-        - name: github
-          put: github
+        - put: github
           params:
             name:   gh/name
             tag:    gh/tag

--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -96,7 +96,7 @@ jobs:
     public: true
     plan:
       - do:
-        - aggregate:
+        - in_parallel:
             - { get: git,     trigger: true,  passed: [test] }
             - { get: version, trigger: true, params: {pre: rc} }
         - put: version
@@ -157,7 +157,7 @@ jobs:
     plan:
       - do:
         - name: inputs
-          aggregate:
+          in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
         - name: release

--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -38,7 +38,6 @@ meta:
 
   slack:
     webhook:       (( param "Please specify your Slack Incoming Webhook Integration URL" ))
-    notification: '(( concat ":sadpanda: " meta.pipeline " build failed!<br>URL-GOES-HERE" ))'
     channel:       (( param "Please specify the channel (#name) or user (@user) to send messages to" ))
     username:      concourse
     icon:          https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png

--- a/bash/pipeline.yml
+++ b/bash/pipeline.yml
@@ -17,7 +17,9 @@ meta:
   target:   (( param "Please identify the name of the target Concourse CI" ))
   pipeline: (( grab meta.name ))
 
-  image:    starkandwayne/concourse
+  image:
+    name: starkandwayne/concourse
+    tag: latest
 
   binaries: '*'
   bin_dir: bin
@@ -65,13 +67,11 @@ jobs:
     plan:
       - do:
         - { get: git, trigger: true }
+        - { get: image }
         - task: test
+          image: image
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image ))
             inputs:
               - name: git
             run:
@@ -156,12 +156,10 @@ jobs:
         - in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
+            - { get: image }
         - task: release
+          image: image
           config:
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image ))
             platform: linux
             inputs:
               - name: version
@@ -208,6 +206,12 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/boshrelease/helpers/initial_settings.yml
+++ b/boshrelease/helpers/initial_settings.yml
@@ -12,6 +12,11 @@ meta:
     email:  ((git-commit-email))
     name:   ((git-commit-name))
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   bosh-lite:
     target:   ((bosh-lite-environment))
     cacert:   ((bosh-lite-ca-cert))

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -30,6 +30,9 @@ meta:
   image:
     name: starkandwayne/concourse
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   aws:
     bucket:     (( grab meta.pipeline ))
@@ -479,6 +482,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -92,14 +92,11 @@ jobs:
     plan:
     - do:
       - { get: git, trigger: true }
+      - { get: image }
       - task: testflight
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - { name: git }
           run:
@@ -132,18 +129,15 @@ jobs:
     plan:
     - do:
       - { get: git-pull-requests, trigger: true, version: every }
+      - { get: image }
       - put: git-pull-requests
         params:
           path: git-pull-requests
           status: pending
       - task: testflight
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - { name: git-pull-requests }
           run:
@@ -173,13 +167,9 @@ jobs:
             path: git-pull-requests
             status: failure
       - task: pr-success-message
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - { name: git-pull-requests }
           outputs:
@@ -212,14 +202,11 @@ jobs:
         trigger: true
       - get: version
         trigger: true
+      - { get: image, passed: [testflight] }
       - task: release-notes
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: starkandwayne/concourse
-              tag: latest
           run:
             path: sh
             args:
@@ -258,14 +245,11 @@ jobs:
     - do:
       - { get: git,     trigger: true,  passed: [pre] }
       - { get: version, trigger: false, params: {pre: rc} }
+      - { get: image,                   passed: [pre] }
       - task: release-notes
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
               - { name: git }
           run:
@@ -346,14 +330,11 @@ jobs:
     - do:
       - { get: version, passed: [rc], params: {bump: final} }
       - { get: git,     passed: [rc] }
+      - { get: image,   passed: [rc] }
       - task: release
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - name: version
             - name: git
@@ -414,14 +395,11 @@ jobs:
         trigger: true
       - get: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
         params: {tarball: false}
+      - { get: image }
       - task: export-release
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - name: git
             - name: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
@@ -456,14 +434,11 @@ jobs:
               params: {tarball: false}
             - get: compiled-release
               passed: [compile-release]
+            - { get: image, passed: [compile-release] }
       - task: use-compiled-releases
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - name: git
             - name: (( concat meta.bosh.stemcell.os "-stemcell-" meta.bosh.stemcell.major ))
@@ -499,6 +474,12 @@ resource_types:
       repository: jtarchie/pr
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -90,11 +90,9 @@ jobs:
     public: true
     serial: true
     plan:
-    - name: main
-      do:
+    - do:
       - { get: git, trigger: true }
-      - name: testflight
-        task: testflight
+      - task: testflight
         config:
           platform: linux
           image_resource:
@@ -132,16 +130,13 @@ jobs:
     public: true
     serial: true
     plan:
-    - name: main
-      do:
+    - do:
       - { get: git-pull-requests, trigger: true, version: every }
-      - name: pending-status
-        put: git-pull-requests
+      - put: git-pull-requests
         params:
           path: git-pull-requests
           status: pending
-      - name: testflight
-        task: testflight
+      - task: testflight
         config:
           platform: linux
           image_resource:
@@ -177,8 +172,7 @@ jobs:
           params:
             path: git-pull-requests
             status: failure
-      - name: pr-success-message
-        task: pr-success-message
+      - task: pr-success-message
         config:
           platform: linux
           image_resource:
@@ -352,8 +346,7 @@ jobs:
     - do:
       - { get: version, passed: [rc], params: {bump: final} }
       - { get: git,     passed: [rc] }
-      - name: release
-        task: release
+      - task: release
         config:
           platform: linux
           image_resource:
@@ -384,28 +377,23 @@ jobs:
             AWS_ACCESS_KEY:       (( grab meta.aws.access_key ))
             AWS_SECRET_KEY:       (( grab meta.aws.secret_key ))
 
-      - name: upload-git
-        put: git
+      - put: git
         params:
           rebase: true
           repository: pushme
-      - name: tarball
-        put: s3-tarball
+      - put: s3-tarball
         params:
           file:  (( concat "gh/artifacts/" meta.name "-*.tgz" ))
-      - name: github-release
-        put: github
+      - put: github
         params:
           name:   gh/name
           tag:    gh/tag
           body:   gh/notes.md
           globs: [gh/artifacts/*]
-      - name: version-bump
-        put: version
+      - put: version
         params:
           bump: patch
-      - name: notify
-        put: notify
+      - put: notify
         params:
           channel:  (( grab meta.slack.channel ))
           username: (( grab meta.slack.username ))
@@ -457,8 +445,7 @@ jobs:
 
   - name: use-compiled-releases
     plan:
-      - name: resources
-        in_parallel:
+      - in_parallel:
           steps:
             - get: git
             - get: github
@@ -495,8 +482,7 @@ jobs:
             GIT_NAME:      (( grab meta.git.name ))
             BRANCH:        (( grab meta.github.branch ))
             STEMCELL_OS:   (( grab meta.bosh.stemcell.os ))
-      - name: upload-git
-        put: git
+      - put: git
         params:
           rebase: true
           repository: pushme

--- a/boshrelease/pipeline.yml
+++ b/boshrelease/pipeline.yml
@@ -531,7 +531,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))

--- a/buildpack/helpers/initial_settings.yml
+++ b/buildpack/helpers/initial_settings.yml
@@ -10,6 +10,11 @@ meta:
     email:  ((git-commit-email))
     name:   ((git-commit-name))
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   aws:
     bucket:      (( grab meta.pipeline ))
     region_name: us-east-1

--- a/buildpack/pipeline.yml
+++ b/buildpack/pipeline.yml
@@ -73,14 +73,11 @@ jobs:
     - do:
       - in_parallel:
         - { get: git, trigger: true }
+        - { get: image }
       - task: unit-tests
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - { name: git }
           run:
@@ -102,14 +99,11 @@ jobs:
     - do:
       - in_parallel:
         - { get: git, trigger: true }
+        - { get: image }
       - task: integration-tests
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - { name: git }
           run:
@@ -182,14 +176,11 @@ jobs:
       - in_parallel:
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
+          - { get: image }
       - task: release
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
             - name: version
             - name: git
@@ -247,6 +238,12 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/buildpack/pipeline.yml
+++ b/buildpack/pipeline.yml
@@ -179,12 +179,10 @@ jobs:
     serial: true
     plan:
     - do:
-      - name: inputs
-        in_parallel:
+      - in_parallel:
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
-      - name: release
-        task: release
+      - task: release
         config:
           platform: linux
           image_resource:
@@ -214,24 +212,20 @@ jobs:
             GIT_EMAIL:      (( grab meta.git.email ))
             GIT_NAME:       (( grab meta.git.name ))
 
-      - name: upload-git
-        put: git
+      - put: git
         params:
           rebase: true
           repository: pushme
-      - name: github-release
-        put: github
+      - put: github
         params:
           name:   gh/name
           tag:    gh/tag
           body:   gh/notes.md
           globs: [gh/artifacts/*]
-      - name: version-bump
-        put: version
+      - put: version
         params:
           bump: patch
-      - name: notify
-        in_parallel:
+      - in_parallel:
         - put: notify
           params:
             channel:  (( grab meta.slack.channel ))

--- a/buildpack/pipeline.yml
+++ b/buildpack/pipeline.yml
@@ -24,6 +24,9 @@ meta:
   image:
     name: starkandwayne/concourse-go
     tag: 1.12
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   cf:
     api_url:         (( param "Please provide api_url" ))
@@ -243,6 +246,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/buildpack/pipeline.yml
+++ b/buildpack/pipeline.yml
@@ -71,7 +71,7 @@ jobs:
     public: true
     plan:
     - do:
-      - aggregate:
+      - in_parallel:
         - { get: git, trigger: true }
       - task: unit-tests
         config:
@@ -100,7 +100,7 @@ jobs:
     serial: true
     plan:
     - do:
-      - aggregate:
+      - in_parallel:
         - { get: git, trigger: true }
       - task: integration-tests
         config:
@@ -133,7 +133,7 @@ jobs:
     public: true
     plan:
     - do:
-      - aggregate:
+      - in_parallel:
           - { get: git,     trigger: true,  passed: [unit-tests, integration-tests] }
           - { get: version, trigger: true, params: {pre: rc} }
       - put: version
@@ -180,7 +180,7 @@ jobs:
     plan:
     - do:
       - name: inputs
-        aggregate:
+        in_parallel:
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
       - name: release
@@ -231,7 +231,7 @@ jobs:
         params:
           bump: patch
       - name: notify
-        aggregate:
+        in_parallel:
         - put: notify
           params:
             channel:  (( grab meta.slack.channel ))

--- a/buildpack/pipeline.yml
+++ b/buildpack/pipeline.yml
@@ -267,7 +267,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))

--- a/cfpush/helpers/initial_settings.yml
+++ b/cfpush/helpers/initial_settings.yml
@@ -4,6 +4,11 @@ meta:
   target:  ${fly_target}
   url:     ${fly_target_url}
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   github:
     owner:  $(jq .OrganizationFields.Name -r ~/.cf/config.json)
     repo:   $(basename $PWD)

--- a/cfpush/pipeline.yml
+++ b/cfpush/pipeline.yml
@@ -45,7 +45,6 @@ jobs:
       - get: app
         trigger: true
       - task: setup-app
-        name: setup-app
         config:
           platform: linux
           image_resource:
@@ -71,7 +70,6 @@ jobs:
         trigger: false
         passed: [deploy-staging]
       - task: setup-app
-        name: setup-app
         config:
           platform: linux
           image_resource:

--- a/cfpush/pipeline.yml
+++ b/cfpush/pipeline.yml
@@ -44,14 +44,11 @@ jobs:
     plan:
       - get: app
         trigger: true
+      - { get: image }
       - task: setup-app
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag: (( grab meta.image.tag ))
           inputs: [{name: app}]
           outputs: [{name: app-with-setup}]
           run:
@@ -69,14 +66,11 @@ jobs:
       - get: app
         trigger: false
         passed: [deploy-staging]
+      - { get: image }
       - task: setup-app
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag: (( grab meta.image.tag ))
           inputs: [{name: app}]
           outputs: [{name: app-with-setup}]
           run:
@@ -89,6 +83,12 @@ jobs:
           show_app_log: true
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: app
     type: git
     source:

--- a/cfpush/pipeline.yml
+++ b/cfpush/pipeline.yml
@@ -9,6 +9,9 @@ meta:
   image:
     name: starkandwayne/concourse
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   github:
     uri:          (( concat "git@github.com:" meta.github.owner "/" meta.github.repo ))
@@ -88,6 +91,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: app
     type: git

--- a/docker/base/helpers/initial_settings.yml
+++ b/docker/base/helpers/initial_settings.yml
@@ -10,6 +10,11 @@ meta:
     email:  ((git-commit-email))
     name:   ((git-commit-name))
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   dockerhub:
     username: ((dockerhub-username))
     email:    ((dockerhub-email))

--- a/docker/base/pipeline.yml
+++ b/docker/base/pipeline.yml
@@ -26,6 +26,9 @@ meta:
   image:
     name: starkandwayne/concourse
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -158,6 +161,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/docker/base/pipeline.yml
+++ b/docker/base/pipeline.yml
@@ -18,11 +18,14 @@ meta:
   target:   (( param "Please identify the name of the target Concourse CI" ))
   url:      (( param "Please specify the full url of the target Concourse CI" ))
   pipeline: (( grab meta.name ))
-  image:    starkandwayne/concourse
 
   git:
     email:  (( param "Please provide the git email for automated commits" ))
     name:   (( param "Please provide the git name for automated commits" ))
+
+  image:
+    name: starkandwayne/concourse
+    tag: latest
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -96,13 +99,11 @@ jobs:
           - { get: version }
           - { get: edge, passed: [build], params: { save: true } }
           - { get: git,  passed: [build] }
+          - { get: image }
 
       - task: release
+        image: image
         config:
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image ))
           platform: linux
           inputs:
             - name: git
@@ -152,6 +153,12 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/docker/base/pipeline.yml
+++ b/docker/base/pipeline.yml
@@ -173,7 +173,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))

--- a/docker/base/pipeline.yml
+++ b/docker/base/pipeline.yml
@@ -92,7 +92,7 @@ jobs:
     public: true
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - { get: version }
           - { get: edge, passed: [build], params: { save: true } }
           - { get: git,  passed: [build] }

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -19,7 +19,9 @@ meta:
   url:      (( param "Please specify the full url of the target Concourse CI" ))
   pipeline: (( grab meta.name ))
 
-  image:    starkandwayne/concourse
+  image:
+    name: starkandwayne/concourse
+    tag: latest
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -94,13 +96,9 @@ jobs:
           - { get: edge,    passed: [build], trigger: true }
           - { get: source,  passed: [build] }
       - task: test-image
+        image: edge
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              .: (( inject meta.dockerhub ))
-              tag:  edge
           inputs:
             - name: source
             - name: tests
@@ -135,13 +133,11 @@ jobs:
           - { get: version }
           - { get: edge,    passed: [test], params: { save: true } }
           - { get: source,  passed: [test] }
+          - { get: image }
 
       - task: release
+        image: image
         config:
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image ))
           platform: linux
           inputs:
             - name: source
@@ -189,6 +185,12 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: source
     type: git
     source:

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -22,6 +22,9 @@ meta:
   image:
     name: starkandwayne/concourse
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -190,6 +193,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: source
     type: git

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -89,13 +89,11 @@ jobs:
     public: true
     serial: true
     plan:
-      - name: get-inputs
-        in_parallel:
+      - in_parallel:
           - { get: tests }
           - { get: edge,    passed: [build], trigger: true }
           - { get: source,  passed: [build] }
-      - name: run-tests
-        task: test-image
+      - task: test-image
         config:
           platform: linux
           image_resource:

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -90,7 +90,7 @@ jobs:
     serial: true
     plan:
       - name: get-inputs
-        aggregate:
+        in_parallel:
           - { get: tests }
           - { get: edge,    passed: [build], trigger: true }
           - { get: source,  passed: [build] }
@@ -133,7 +133,7 @@ jobs:
     public: true
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
           - { get: version }
           - { get: edge,    passed: [test], params: { save: true } }
           - { get: source,  passed: [test] }

--- a/docker/ext-tests/pipeline.yml
+++ b/docker/ext-tests/pipeline.yml
@@ -219,7 +219,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       key:               version

--- a/go/helpers/initial_settings.yml
+++ b/go/helpers/initial_settings.yml
@@ -15,6 +15,11 @@ meta:
     email:  ((git-commit-email))
     name:   ((git-commit-name))
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   aws:
     bucket:      (( grab meta.pipeline ))
     region_name: us-east-1

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -31,6 +31,9 @@ meta:
   image:
     name: starkandwayne/concourse-go
     tag: (( grab meta.go.version ))
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   aws:
     bucket:      (( concat meta.pipeline "-pipeline" ))
@@ -340,6 +343,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -279,12 +279,10 @@ jobs:
     serial: true
     plan:
       - do:
-        - name: inputs
-          in_parallel:
+        - in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
-        - name: release
-          task: release
+        - task: release
           config:
             image_resource:
               type: docker-image
@@ -314,23 +312,19 @@ jobs:
               STATIC_BINARY:  (( grab meta.go.force_static_binary ))
               GIT_EMAIL:      (( grab meta.git.email ))
               GIT_NAME:       (( grab meta.git.name ))
-        - name: version
-          put: version
+        - put: version
           params: { bump: final }
-        - name: git
-          put: git
+        - put: git
           params:
             rebase: true
             repository: pushme/git
-        - name: github
-          put: github
+        - put: github
           params:
             name:   gh/name
             tag:    gh/tag
             body:   gh/notes.md
             globs: [gh/artifacts/*]
-        - name: notify
-          in_parallel:
+        - in_parallel:
           - put: notify
             params:
               channel:  (( grab meta.slack.channel ))

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -77,14 +77,11 @@ jobs:
     plan:
       - do:
         - { get: git, trigger: true }
+        - { get: image }
         - task: test
+          image: image
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image.name ))
-                tag:        (( grab meta.image.tag ))
             inputs:
               - name: git
                 path: (( concat "gopath/src/" meta.go.module ))
@@ -107,18 +104,15 @@ jobs:
     plan:
       - do:
         - { get: git-pull-requests, trigger: true, version: every }
+        - { get: image }
         - put: git-pull-requests
           params:
             path: git-pull-requests
             status: pending
         - task: test
+          image: image
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image.name ))
-                tag:        (( grab meta.image.tag ))
             inputs:
               - name: git-pull-requests
                 path: (( concat "gopath/src/" meta.go.module ))
@@ -138,13 +132,9 @@ jobs:
               path: git-pull-requests
               status: failure
         - task: pr-success-message
+          image: image
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image.name ))
-                tag:        (( grab meta.image.tag ))
             inputs:
               - { name: git-pull-requests }
             outputs:
@@ -177,14 +167,11 @@ jobs:
         trigger: true
       - get: version
         trigger: true
+      - { get: image, passed: [testflight] }
       - task: release-notes
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: starkandwayne/concourse
-              tag: latest
           run:
             path: sh
             args:
@@ -282,13 +269,10 @@ jobs:
         - in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
+            - { get: image,   passed: [rc] }
         - task: release
+          image: image
           config:
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image.name ))
-                tag:        (( grab meta.image.tag ))
             platform: linux
             inputs:
               - name: version
@@ -351,6 +335,12 @@ resource_types:
       repository: jtarchie/pr
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -367,7 +367,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -220,7 +220,7 @@ jobs:
     public: true
     plan:
       - do:
-        - aggregate:
+        - in_parallel:
             - { get: git,     trigger: true,  passed: [pre] }
             - { get: version, trigger: false, params: {pre: rc} }
         - put: version
@@ -281,7 +281,7 @@ jobs:
     plan:
       - do:
         - name: inputs
-          aggregate:
+          in_parallel:
             - { get: version, passed: [rc], params: {bump: final} }
             - { get: git,     passed: [rc] }
         - name: release
@@ -331,7 +331,7 @@ jobs:
             body:   gh/notes.md
             globs: [gh/artifacts/*]
         - name: notify
-          aggregate:
+          in_parallel:
           - put: notify
             params:
               channel:  (( grab meta.slack.channel ))

--- a/go/pipeline.yml
+++ b/go/pipeline.yml
@@ -50,7 +50,6 @@ meta:
     webhook:       (( param "Please specify your Slack Incoming Webhook Integration URL" ))
     username:      concourse
     icon:          https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
-    notification: '(( concat ":sadpanda: " meta.pipeline " build failed!<br>URL-GOES-HERE" ))'
     channel:       (( param "Please specify the channel (#name) or user (@user) to send messages to" ))
     fail_moji:     ":airplane_arriving:"
     success_moji:  ":airplane_departure:"

--- a/helm/helpers/initial_settings.yml
+++ b/helm/helpers/initial_settings.yml
@@ -13,6 +13,11 @@ meta:
     email:  ((git-commit-email))
     name:   ((git-commit-name))
 
+  image:
+    registry:
+      username: ((docker_registry_username))
+      password: ((docker-registry-password))
+
   aws:
     bucket:      (( grab meta.pipeline ))
     region_name: us-east-1

--- a/helm/pipeline.yml
+++ b/helm/pipeline.yml
@@ -17,9 +17,6 @@ meta:
   target:   (( param "Please identify the name of the target Concourse CI" ))
   url:      (( param "Please specify the full url of the target Concourse CI" ))
   pipeline: (( grab meta.name ))
-  image:
-    name: starkandwayne/concourse-kubernetes
-    tag: latest
 
   helm:
     chart_path: .
@@ -27,6 +24,10 @@ meta:
   git:
     email:  (( param "Please provide the git email for automated commits" ))
     name:   (( param "Please provide the git name for automated commits" ))
+
+  image:
+    name: starkandwayne/concourse-kubernetes
+    tag: latest
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -98,19 +99,16 @@ jobs:
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
           - { get: image-latest, passed: [latest-image], params: { save: true } }
+          - { get: image }
       - in_parallel:
         - put: image-latest # as 'vX.Y.Z'
           params:
             tag:        version/number
             load:       image-latest
         - task: package-chart
+          image: image
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: (( grab meta.image.name ))
-                tag:        (( grab meta.image.tag ))
             inputs:
               - name: version
               - name: git
@@ -176,14 +174,11 @@ jobs:
           # - { get: git,     trigger: true }
           - { get: git,     trigger: true, passed: [latest-image] }
           - { get: version, trigger: true, params: {pre: rc} }
+          - { get: image }
       - task: release-notes
+        image: image
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: (( grab meta.image.name ))
-              tag:        (( grab meta.image.tag ))
           inputs:
               - { name: git }
           run:
@@ -248,6 +243,12 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
 
 resources:
+  - name: image
+    type: docker-image
+    source:
+      repository: (( grab meta.image.name ))
+      tag:        (( grab meta.image.tag ))
+
   - name: git
     type: git
     source:

--- a/helm/pipeline.yml
+++ b/helm/pipeline.yml
@@ -92,21 +92,18 @@ jobs:
     serial: true
     plan:
     - do:
-      - name: inputs
-        in_parallel:
+      - in_parallel:
           # - { get: version,  params: {bump: final} }
           # - { get: git }
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
           - { get: image-latest, passed: [latest-image], params: { save: true } }
       - in_parallel:
-        - name: docker-push-tag
-          put: image-latest # as 'vX.Y.Z'
+        - put: image-latest # as 'vX.Y.Z'
           params:
             tag:        version/number
             load:       image-latest
-        - name: package-chart
-          task: package-chart
+        - task: package-chart
           config:
             platform: linux
             image_resource:
@@ -141,20 +138,17 @@ jobs:
               AWS_DEFAULT_REGION:    (( grab meta.aws.region_name ))
               HELM_S3_BUCKET_URI:    (( grab meta.aws.charts_uri ))
 
-      - name: upload-git
-        put: git
+      - put: git
         params:
           rebase: true
           repository: (( grab meta.name ))
-      - name: github-release
-        put: github
+      - put: github
         params:
           name:   gh/name
           tag:    gh/tag
           body:   gh/notes.md
           globs: [gh/artifacts/*]
-      - name: version-bump
-        put: version
+      - put: version
         params:
           bump: patch
       # - name: notify

--- a/helm/pipeline.yml
+++ b/helm/pipeline.yml
@@ -28,6 +28,9 @@ meta:
   image:
     name: starkandwayne/concourse-kubernetes
     tag: latest
+    registry:
+      username: (( param "Please set your Docker registry username for your pipeline image" ))
+      password: (( param "Please set your Docker registry password for your pipeline image" ))
 
   aws:
     bucket:     (( concat meta.name "-pipeline" ))
@@ -248,6 +251,8 @@ resources:
     source:
       repository: (( grab meta.image.name ))
       tag:        (( grab meta.image.tag ))
+      username:   (( grab meta.image.registry.username ))
+      password:   (( grab meta.image.registry.password ))
 
   - name: git
     type: git

--- a/helm/pipeline.yml
+++ b/helm/pipeline.yml
@@ -93,13 +93,13 @@ jobs:
     plan:
     - do:
       - name: inputs
-        aggregate:
+        in_parallel:
           # - { get: version,  params: {bump: final} }
           # - { get: git }
           - { get: version, passed: [rc], params: {bump: final} }
           - { get: git,     passed: [rc] }
           - { get: image-latest, passed: [latest-image], params: { save: true } }
-      - aggregate:
+      - in_parallel:
         - name: docker-push-tag
           put: image-latest # as 'vX.Y.Z'
           params:
@@ -158,7 +158,7 @@ jobs:
         params:
           bump: patch
       # - name: notify
-      #   aggregate:
+      #   in_parallel:
       #   - put: notify
       #     params:
       #       channel:  (( grab meta.slack.channel ))
@@ -178,7 +178,7 @@ jobs:
     serial: true
     plan:
     - do:
-      - aggregate:
+      - in_parallel:
           # - { get: git,     trigger: true }
           - { get: git,     trigger: true, passed: [latest-image] }
           - { get: version, trigger: true, params: {pre: rc} }

--- a/helm/pipeline.yml
+++ b/helm/pipeline.yml
@@ -269,7 +269,7 @@ resources:
 
   - name: version
     type: semver
-    source :
+    source:
       driver:            s3
       bucket:            (( grab meta.aws.bucket ))
       region_name:       (( grab meta.aws.region_name ))


### PR DESCRIPTION
Hello!
As a preliminary notice, this PR is based on top of the `update-syntax` branch, already submitted in #40.
Thus the diffs here include those of #40 until that PR is merged.

Here I've factored all the individual `image_resource` configs appearing in tasks, into a single image resource. This unclutters the YAML code and reduces image-pull pressure on Docker Hub, useful since they've implemented quotas.
Then, in a second commit, I've added properties for authenticating to the Docker registry where the CI image resides. This is also useful in order to escape the very reduced Docker Hub quotas on anonymous image pulls, or to nicely leverage some private registry like we do in our company.
Hope this can help!
Best
