### PR TITLE
setup: quote variables in checks

### DIFF
--- a/setup
+++ b/setup
@@ -48,8 +48,8 @@ initial_settings_yml() {
   fi
 }
 
-[ -n ${template} ] || usage "ERROR: Missing pipeline template type" 1
-[ -d ${target} ]   || usage "ERROR: ${target} path not found"       1
+[ -n "${template}" ] || usage "ERROR: Missing pipeline template type" 1
+[ -d "${target}" ]   || usage "ERROR: ${target} path not found"       1
 
 pattern="^($(echo "$pipeline_types" | tr "\n" "|" | sed -e "s/\|*$//"))$"
 [[ "${template}"=~$pattern ]] || usage "ERROR: ${template} is not a valid pipeline template" 1


### PR DESCRIPTION
Without "" around the variable, if they are unset, no string is visible
to bash and the test incorrectly passes.