### PR TITLE
repipe: prefer CONCOURSE_TARGET settings.yml

### DIFF
--- a/repipe
+++ b/repipe
@@ -95,7 +95,7 @@ echo >&2 "Working in $(pwd)"
 need_command spruce
 
 # Allow for target-specific settings
-settings_file="$(ls -1 settings.yml ${CONCOURSE_TARGET:+"settings-${CONCOURSE_TARGET}.yml"} 2>/dev/null | tail -n1)"
+settings_file="$(ls -1 settings.yml ${CONCOURSE_TARGET:+"settings-${CONCOURSE_TARGET}.yml"} 2>/dev/null | head -n1)"
 if [[ -z "$settings_file" ]]
 then
   echo >&2 "Missing local settings in ci/settings.yml${CONCOURSE_TARGET:+" or ci/settings-${CONCOURSE_TARGET}.yml"}!"


### PR DESCRIPTION
`.` sorts after `-`, so `settings.yml` will always sort after `settings-${CONCOURSE_TARGET}.yml` no matter what the value of `CONCOURSE_TARGET` is. As `tail` is used to select the last sorted result, if `settings.yml` is present then it will always be preferred.

This commit selects the first sorted result, to prefer `settings-${CONCOURSE_TARGET}.yml` over `settings.yml`. (No other logic is changed: if `CONCOURSE_TARGET` is not set, or such a settings file does not exist, `settings.yml` will continue to be used.)